### PR TITLE
Do not treat negated constant as a magic number

### DIFF
--- a/src/Rules/MagicNumber/AbstractMagicNumberRule.php
+++ b/src/Rules/MagicNumber/AbstractMagicNumberRule.php
@@ -29,7 +29,8 @@ abstract class AbstractMagicNumberRule implements Rule
     {
         $isNumber = $expr instanceof LNumber
             || $expr instanceof DNumber
-            || $expr instanceof Expr\UnaryMinus;
+            || ($expr instanceof Expr\UnaryMinus && $this->isNumber($expr->expr))
+            || ($expr instanceof Expr\UnaryPlus && $this->isNumber($expr->expr));
 
         return $isNumber && !$this->ignoreNumber($expr);
     }

--- a/tests/Rules/MagicNumber/NoMagicNumberAssignedToPropertyRuleTest.php
+++ b/tests/Rules/MagicNumber/NoMagicNumberAssignedToPropertyRuleTest.php
@@ -16,11 +16,11 @@ final class NoMagicNumberAssignedToPropertyRuleTest extends AbstractMagicNumberT
             [
                 [
                     NoMagicNumberAssignedToPropertyRule::ERROR_MESSAGE,
-                    5,
+                    7,
                 ],
                 [
                     NoMagicNumberAssignedToPropertyRule::ERROR_MESSAGE,
-                    7,
+                    9,
                 ],
             ]
         );

--- a/tests/Rules/MagicNumber/NoMagicNumberInDefaultParameterRuleTest.php
+++ b/tests/Rules/MagicNumber/NoMagicNumberInDefaultParameterRuleTest.php
@@ -16,7 +16,7 @@ final class NoMagicNumberInDefaultParameterRuleTest extends AbstractMagicNumberT
             [
                 [
                     NoMagicNumberInDefaultParameterRule::ERROR_MESSAGE,
-                    9,
+                    11,
                 ],
             ]
         );

--- a/tests/Rules/MagicNumber/NoMagicNumberInReturnStatementRuleTest.php
+++ b/tests/Rules/MagicNumber/NoMagicNumberInReturnStatementRuleTest.php
@@ -16,11 +16,27 @@ final class NoMagicNumberInReturnStatementRuleTest extends AbstractMagicNumberTe
             [
                 [
                     NoMagicNumberInReturnStatementRule::ERROR_MESSAGE,
-                    11,
+                    13,
                 ],
                 [
                     NoMagicNumberInReturnStatementRule::ERROR_MESSAGE,
-                    16,
+                    18,
+                ],
+                [
+                    NoMagicNumberInReturnStatementRule::ERROR_MESSAGE,
+                    32,
+                ],
+                [
+                    NoMagicNumberInReturnStatementRule::ERROR_MESSAGE,
+                    37,
+                ],
+                [
+                    NoMagicNumberInReturnStatementRule::ERROR_MESSAGE,
+                    42,
+                ],
+                [
+                    NoMagicNumberInReturnStatementRule::ERROR_MESSAGE,
+                    47,
                 ],
             ]
         );

--- a/tests/Rules/MagicNumber/data/class-cases.php
+++ b/tests/Rules/MagicNumber/data/class-cases.php
@@ -2,6 +2,8 @@
 
 class Test
 {
+    private const CONST1 = 10;
+
     private $prop1 = 10;
 
     private $prop2 = -5.5;
@@ -23,5 +25,40 @@ class Test
 
     public function returnVoid(): void
     {
+    }
+
+    public function returnValueWithNegatedUnaryMinus(): int
+    {
+        return -(-1.1);
+    }
+
+    public function returnValueWithUnaryPlus(): int
+    {
+        return +1.1;
+    }
+
+    public function returnValueWithNegatedUnaryPlus(): int
+    {
+        return -(+1.1);
+    }
+
+    public function returnValueWithDoubleUnaryPlus(): int
+    {
+        return +(+1.1);
+    }
+
+    public function returnConstWithUnaryMinus(): int
+    {
+        return -self::CONST1;
+    }
+
+    public function returnConstWithNegatedUnaryMinus(): int
+    {
+        return -(-self::CONST1);
+    }
+
+    public function returnConstWithUnaryPlus(): int
+    {
+        return +self::CONST1;
     }
 }


### PR DESCRIPTION
Do not treat negated constant as a magic number

```php
return -self::CONST
```

is not a magic number.

Additionally, correctly handle `UnaryPlus` as well as `UnaryMinus` and add more tests for different combinations of `+` and `-` with constants and raw values.