### PR TITLE
Fix false-positive with ternary operator wher `if` part is omitted

### DIFF
--- a/src/Rules/MagicNumber/NoMagicNumberInTernaryOperatorRule.php
+++ b/src/Rules/MagicNumber/NoMagicNumberInTernaryOperatorRule.php
@@ -26,7 +26,11 @@ final class NoMagicNumberInTernaryOperatorRule extends AbstractMagicNumberRule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$this->isNumber($node->else) && $node->if !== null && !$this->isNumber($node->if)) {
+        if ($node->if !== null && !$this->isNumber($node->else) && !$this->isNumber($node->if)) {
+            return [];
+        }
+
+        if ($node->if === null && !$this->isNumber($node->else) && !$this->isNumber($node->if)) {
             return [];
         }
 

--- a/tests/Rules/MagicNumber/NoMagicNumberInTernaryOperatorRuleTest.php
+++ b/tests/Rules/MagicNumber/NoMagicNumberInTernaryOperatorRuleTest.php
@@ -16,15 +16,15 @@ final class NoMagicNumberInTernaryOperatorRuleTest extends AbstractMagicNumberTe
             [
                 [
                     NoMagicNumberInTernaryOperatorRule::ERROR_MESSAGE,
-                    5,
+                    6,
                 ],
                 [
                     NoMagicNumberInTernaryOperatorRule::ERROR_MESSAGE,
-                    7,
+                    8,
                 ],
                 [
                     NoMagicNumberInTernaryOperatorRule::ERROR_MESSAGE,
-                    9,
+                    10,
                 ],
             ]
         );

--- a/tests/Rules/MagicNumber/data/ternary-cases.php
+++ b/tests/Rules/MagicNumber/data/ternary-cases.php
@@ -1,9 +1,12 @@
 <?php
 
 $b = true;
+$string = 'string';
 
 $a = $b ? 2 : 'string';
 
 $c = $b ?: -3.5;
 
 $d = $b ? 'string' : 6;
+
+$d = $b ?: $string;


### PR DESCRIPTION
Before this update, the following **valid** code triggered false-positive complaint from `NoMagicNumberInTernaryOperatorRule.php`:

```php
$b = true;
$string = 'string';

$d = $b ?: $string;
```