### PR TITLE
Drop old PHP versions to move the project ahead

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: [ '8.1', '8.2' ]
 
     name: Tests on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
 
       - name: Get composer cache directory
         id: composer-cache

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "source": "https://github.com/sidz/phpstan-rules"
     },
     "require": {
-        "php": "^7.2 || ^8.0, <8.3",
+        "php": "^8.1, <8.3",
         "phpstan/phpstan": "^1.8",
         "nikic/php-parser": "^4.14"
     },
@@ -39,6 +39,9 @@
         }
     },
     "config": {
+        "platform": {
+            "php": "8.1.0"
+        },
         "sort-packages": true,
         "preferred-install": "dist"
     },


### PR DESCRIPTION
This will allow to do the following:

- upgrade dependencies to the latest versions, including
  - PHPStan and extension-installer
  - PHPUnit
- add Infection

With the existing tags, people will still be able to use this plugin on older PHP 7.* versions.

Related to https://github.com/phpstan/phpstan/pull/9348