### PR TITLE
Configure plugin to be used with `phpstan/extension-installer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ Run
 composer require --dev sidz/phpstan-rules
 ```
 
-## Add Static Rules to `phpstan.neon`
-
-Currently, you need to manually register all the rules in your `phpstan.neon`:
+If you use [PHPStan extension installer](https://github.com/phpstan/extension-installer), you're all set. If not, you need to manually register all the rules in your `phpstan.neon`:
 
 ```neon
 includes:

--- a/composer.json
+++ b/composer.json
@@ -45,5 +45,12 @@
         "sort-packages": true,
         "preferred-install": "dist"
     },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "rules.neon"
+            ]
+        }
+    },
     "prefer-stable": true
 }


### PR DESCRIPTION
Depends on https://github.com/sidz/phpstan-rules/pull/7 and https://github.com/sidz/phpstan-rules/pull/8 (see the last commit only)

- [x] Check if it really works, by requesting this branch on some real project