### PR TITLE
Enable back Infection, fix new mutants

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,10 +57,10 @@ jobs:
         shell: bash
         run: make tests
 
-#      - name: Run Infection for touched lines
-#        shell: bash
-#        if: github.event_name == 'pull_request'
-#        run: |
-#          git fetch origin $GITHUB_BASE_REF
-#          vendor/bin/infection --threads=max --only-covered --show-mutations --min-covered-msi=100 --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations
+      - name: Run Infection for touched lines
+        shell: bash
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin $GITHUB_BASE_REF
+          vendor/bin/infection --threads=max --only-covered --show-mutations --min-covered-msi=100 --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",
+        "infection/infection": "^0.28.0",
         "phpunit/phpunit": "^10.1"
     },
     "autoload": {

--- a/infection.json5
+++ b/infection.json5
@@ -11,6 +11,12 @@
             "ignore": [
                 "Sid\\PHPStan\\Rules\\MagicNumber\\AbstractMagicNumberRule::isNumericString"
             ]
+        },
+        "FalseValue": {
+            "ignore": [
+                // because in current tests Rule is always created with $ignoreNumericStrings=false
+                "Sid\\PHPStan\\Rules\\MagicNumber\\AbstractMagicNumberRule::__construct"
+            ]
         }
     }
 }

--- a/src/Rules/MagicNumber/NoMagicNumberInArithmeticOperatorRule.php
+++ b/src/Rules/MagicNumber/NoMagicNumberInArithmeticOperatorRule.php
@@ -19,11 +19,11 @@ final class NoMagicNumberInArithmeticOperatorRule extends AbstractMagicNumberRul
 
     public function getNodeType(): string
     {
-        return Node\Expr\BinaryOp::class;
+        return BinaryOp::class;
     }
 
     /**
-     * @param Node\Expr\BinaryOp $node
+     * @param BinaryOp $node
      */
     public function processNode(Node $node, Scope $scope): array
     {

--- a/tests/Rules/MagicNumber/NoMagicNumberInMatchCaseRuleTest.php
+++ b/tests/Rules/MagicNumber/NoMagicNumberInMatchCaseRuleTest.php
@@ -36,7 +36,11 @@ final class NoMagicNumberInMatchCaseRuleTest extends AbstractMagicNumberTestCase
                 ],
                 [
                     NoMagicNumberInMatchRule::MATCH_ARM_COND_MESSAGE,
-                    8,
+                    9,
+                ],
+                [
+                    NoMagicNumberInMatchRule::MATCH_ARM_COND_MESSAGE,
+                    9,
                 ],
             ]
         );

--- a/tests/Rules/MagicNumber/NoMagicNumberInSwitchCaseRuleTest.php
+++ b/tests/Rules/MagicNumber/NoMagicNumberInSwitchCaseRuleTest.php
@@ -24,11 +24,14 @@ final class NoMagicNumberInSwitchCaseRuleTest extends AbstractMagicNumberTestCas
                 ],
                 [
                     NoMagicNumberInSwitchCaseRule::ERROR_MESSAGE,
-                    6,
+                    8,
+                ],                [
+                    NoMagicNumberInSwitchCaseRule::ERROR_MESSAGE,
+                    10,
                 ],
                 [
                     NoMagicNumberInSwitchCaseRule::ERROR_CONDITION_MESSAGE,
-                    11,
+                    15,
                 ],
             ]
         );

--- a/tests/Rules/MagicNumber/data/match-case.php
+++ b/tests/Rules/MagicNumber/data/match-case.php
@@ -5,7 +5,8 @@ $input = 3;
 match (3) {
     1 => 'Hi',
     2, 4 => 'There',
-    '1', 5 => 'magic number after string',
+    'string in the middle', '5' => 'There',
+    '1', 6 => 'magic number after string',
     default => throw new LogicException(),
     0 => 'Hello',
 };

--- a/tests/Rules/MagicNumber/data/switch-case.php
+++ b/tests/Rules/MagicNumber/data/switch-case.php
@@ -3,6 +3,10 @@
 switch (100) {
     case 5:
         break;
+    case 'string in the middle':
+        break;
+    case 6:
+        break;
     case '10':
         break;
 }


### PR DESCRIPTION
- Add more tests to kill muations
- ignore hard-to-kill muation (requires somehow instantiate the Rule with no `$ignoreNumericStrings` parameter, so default value is used in constructor)