### PR TITLE
Fix "sidzIgnoreMagicNumbers" is not working for numeric-strings

### DIFF
--- a/src/Rules/MagicNumber/AbstractMagicNumberRule.php
+++ b/src/Rules/MagicNumber/AbstractMagicNumberRule.php
@@ -39,7 +39,7 @@ abstract class AbstractMagicNumberRule implements Rule
      */
     private function ignoreNumber(Expr $scalar): bool
     {
-        return in_array($scalar->value, $this->ignoreMagicNumbers, true);
+        return in_array((string) $scalar->value, array_map('strval', $this->ignoreMagicNumbers), true);
     }
 
     private function isNumericString(?Expr $expr): bool

--- a/tests/Rules/MagicNumber/data/assignment-case.php
+++ b/tests/Rules/MagicNumber/data/assignment-case.php
@@ -9,7 +9,7 @@ function test_func($var4 = 3): void
     $var5 = 0;
     $var5_1 = 1;
     $var5_2 = 2;
-    $var = '0';
+    $var = '3';
 }
 
 $var6 = .1;
@@ -37,3 +37,5 @@ $var = '10';
 $var = '-5';
 
 $var = new stdClass();
+
+$var = '0';

--- a/tests/Rules/MagicNumber/data/match-case.php
+++ b/tests/Rules/MagicNumber/data/match-case.php
@@ -6,7 +6,7 @@ match (3) {
     1 => 'Hi',
     2, 4 => 'There',
     'string in the middle', '5' => 'There',
-    '1', 6 => 'magic number after string',
+    '2', 6 => 'magic number after string',
     default => throw new LogicException(),
     0 => 'Hello',
 };


### PR DESCRIPTION
This PR fixes the issue reported in the https://github.com/sidz/phpstan-rules/issues/23.