### PR TITLE
Move nikic/php-parser from prod to dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     },
     "require": {
         "php": "^8.1, <8.4",
-        "nikic/php-parser": "^4.14 || ^5.0",
         "phpstan/phpstan": "^1.8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",
         "infection/infection": "^0.28.0",
+        "nikic/php-parser": "^4.14 || ^5.0",
         "phpunit/phpunit": "^10.1"
     },
     "autoload": {


### PR DESCRIPTION
This PR moves `nikic/php-parser` from prod to dev dependency as phpstan has own dependency and it doesn't make a lot of sense to install `nikic/php-parser` in a case when end user of this package install phpstan as phar.
