### PR TITLE
Backport PHP 8.4 support to 0.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '8.1', '8.2', '8.3' ]
+        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
 
     name: Tests on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/sidz/phpstan-rules"
     },
     "require": {
-        "php": "^8.1, <8.4",
+        "php": "^8.1, <8.5",
         "phpstan/phpstan": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
This PR backports changes made in the https://github.com/sidz/phpstan-rules/pull/29 but for 0.4 as it supports phpstan 1 only 